### PR TITLE
Minor corrections to Translator use

### DIFF
--- a/MMM-Voice-Control.js
+++ b/MMM-Voice-Control.js
@@ -1,3 +1,5 @@
+/* global Module */
+
 Module.register("MMM-Voice-Control", {
 
 	// Default module config.
@@ -35,14 +37,14 @@ Module.register("MMM-Voice-Control", {
 	},
 
 	restCommand: function(scope) {
-		scope.interimResult = Translator.translate(this, "home").commands;
+		scope.interimResult = scope.translate("home").commands;
 		scope.updateDom(500);
 	},
 
 	setLanguage: function() {
 		moment.locale(config.language);
 		this.annyangService.setLanguage(config.language);
-		this.interimResult = Translator.translate(this, "home").commands;
+		this.interimResult = this.translate("home").commands;
 	},
 
 	start: function() {
@@ -62,9 +64,9 @@ Module.register("MMM-Voice-Control", {
 	},
 
 	registerCommand: function(commandId, commandFunction) {
-		var voiceTranslation = Translator.translate(this, "commands")[commandId].voice;
-		var textTranslation = Translator.translate(this, "commands")[commandId].text;
-		var descTranslation = Translator.translate(this, "commands")[commandId].description;
+		var voiceTranslation = this.translate("commands")[commandId].voice;
+		var textTranslation = this.translate("commands")[commandId].text;
+		var descTranslation = this.translate("commands")[commandId].description;
 		this.readableCommands.commands.push(textTranslation + ": " + descTranslation);
 		this.annyangService.registerCommand(voiceTranslation, commandFunction);
 	},

--- a/MMM-Voice-Control.js
+++ b/MMM-Voice-Control.js
@@ -8,7 +8,7 @@ Module.register("MMM-Voice-Control", {
 	},
 
 	getScripts: function() {
-		return ['annyang.js', 'annyang-service.js', 'moment.js', 'commands.js']
+		return ['annyang.js', 'annyang-service.js', 'moment.js', 'commands.js'];
 	},
 
 	// Define required scripts.
@@ -20,10 +20,10 @@ Module.register("MMM-Voice-Control", {
 		return {
 			en: "translations/en.json",
 			de: "translations/de.json",
-			de: "translations/es.json",
-			de: "translations/fr.json",
-			de: "translations/ko.json"
-		}
+			es: "translations/es.json",
+			fr: "translations/fr.json",
+			ko: "translations/ko.json"
+		};
 	},
 
 	// Override dom generator.
@@ -35,14 +35,14 @@ Module.register("MMM-Voice-Control", {
 	},
 
 	restCommand: function(scope) {
-		scope.interimResult = Translator.translations[this.name].home.commands;
-		scope.updateDom();
+		scope.interimResult = Translator.translate(this, "home").commands;
+		scope.updateDom(500);
 	},
 
 	setLanguage: function() {
 		moment.locale(config.language);
 		this.annyangService.setLanguage(config.language);
-		this.interimResult = Translator.translations[this.name].home.commands;
+		this.interimResult = Translator.translate(this, "home").commands;
 	},
 
 	start: function() {
@@ -54,7 +54,7 @@ Module.register("MMM-Voice-Control", {
 		this.readableCommands = {
 			header: this.interimResult,
 			commands: []
-		}
+		};
 
 		CommandManager(this);
 
@@ -62,37 +62,39 @@ Module.register("MMM-Voice-Control", {
 	},
 
 	registerCommand: function(commandId, commandFunction) {
-		var voiceTranslation = Translator.translations[this.name].commands[commandId].voice;
-		var textTranslation = Translator.translations[this.name].commands[commandId].text;
-		var descTranslation = Translator.translations[this.name].commands[commandId].description;
-		this.readableCommands.commands.push(textTranslation + ": " + descTranslation)
+		var voiceTranslation = Translator.translate(this, "commands")[commandId].voice;
+		var textTranslation = Translator.translate(this, "commands")[commandId].text;
+		var descTranslation = Translator.translate(this, "commands")[commandId].description;
+		this.readableCommands.commands.push(textTranslation + ": " + descTranslation);
 		this.annyangService.registerCommand(voiceTranslation, commandFunction);
 	},
 
 	startAnnayang: function() {
-		var self = this
+		var self = this;
 		var resetCommandTimeout;
-		this.annyangService.start(
-			function(){
+		self.annyangService.start(
+			function() {
 				self.isListening = true;
 			},
-			function(interimResult){
+			function(interimResult) {
 				self.interimResult = interimResult;
 				window.clearTimeout(resetCommandTimeout);
-				Log.info("Interim result: " + self.interimResult)
-				self.updateDom()
+				Log.info("Interim result: " + self.interimResult);
+				self.updateDom(500);
 			},
-			function(result){
-				if(typeof result != 'undefined'){
+			function(result) {
+				if (typeof result != 'undefined') {
 					self.interimResult = result[0];
 					resetCommandTimeout = window.setTimeout(function() {
-						self.restCommand(self)
-					}, self.config.voiceTextRestTimeout);
+							self.restCommand(self);
+						},
+						self.config.voiceTextRestTimeout
+					);
 				}
 			},
-			function(error){
+			function(error) {
 				console.log(error);
-				if(error.error == "network"){
+				if (error.error == "network") {
 					self.speechError = "Google Speech Recognizer is down :(";
 					self.annyangService.abort();
 					self.isListening = false;

--- a/README.md
+++ b/README.md
@@ -5,11 +5,9 @@ This an extension for the [MagicMirror](https://github.com/MichMich/MagicMirror)
 
 ## Installation
 1. Navigate into your MagicMirror's `modules` folder and execute 
-
 ```bash
 git clone https://github.com/dr4ke616/MMM-Voice-Control.git
 ```
-
 2. Navigate back to MagicMirror's root directory
 3. Start magic mirror
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ git clone https://github.com/dr4ke616/MMM-Voice-Control.git
 ```
 
 2. Navigate back to MagicMirror's root directory
-4. Start magic mirror
+3. Start magic mirror
 
 ## Supported Commands:
 
@@ -27,6 +27,7 @@ To use this module, add it to the modules array in the `config/config.js` file:
 modules: [
     {
         module: 'MMM-Voice-Control',
+        position: 'lower_third', // If you want to see the prompt and recognised speech, omit otherwise
         config: {
             // See 'Configuration options' for more information.
         }
@@ -76,7 +77,7 @@ The following properties can be configured:
 
 ## Extending
 
-Its quiet simple to add more custom commands. 
+Its quite simple to add more custom commands. 
 
 - Add the extra needed local values to any of the files in the `MMM-Voice-Control/translations/`.
-- The behaviour can then be defined in the `MMM-Voice-Control/commands.js` file. It is recommended to interface with other modules using Smart Mirror's default alert module. 
+- The behaviour can then be defined in the `MMM-Voice-Control/commands.js` file. It is recommended to interface with other modules using MagicMirror's default alert module. 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,10 @@ Magic Mirror Module - Voice Control
 This an extension for the [MagicMirror](https://github.com/MichMich/MagicMirror) to allow use of voice commands. Currently it is a very minimal module with support only for [MMM-Dublin-Bus](https://github.com/dr4ke616/MMM-Dublin-Bus)
 
 ## Installation
-1. Navigate into your MagicMirror's `modules` folder and execute 
-	```bash
-	git clone https://github.com/dr4ke616/MMM-Voice-Control.git
-	```
-2. Navigate back to MagicMirror's root directory
-3. Start magic mirror
+1. Navigate into your MagicMirror's `modules` folder
+2. Execute `git clone https://github.com/dr4ke616/MMM-Voice-Control.git`
+3. Navigate back to MagicMirror's root directory
+4. Start magic mirror
 
 ## Supported Commands:
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ This an extension for the [MagicMirror](https://github.com/MichMich/MagicMirror)
 
 ## Installation
 1. Navigate into your MagicMirror's `modules` folder and execute 
-```bash
-git clone https://github.com/dr4ke616/MMM-Voice-Control.git
-```
+	```bash
+	git clone https://github.com/dr4ke616/MMM-Voice-Control.git
+	```
 2. Navigate back to MagicMirror's root directory
 3. Start magic mirror
 

--- a/commands.js
+++ b/commands.js
@@ -7,25 +7,25 @@ function CommandManager(scope) {
 			message: scope.readableCommands.commands.join("</p><p>"),
 			timer: scope.config.listOfCommandsNotificationTime
 		});
-	})
+	});
 
 	scope.registerCommand('sleep', function() {
 		MM.getModules().enumerate(function(module) {
 			module.hide(1000);
 		});
-	})
+	});
 
 	scope.registerCommand('wake_up', function() {
 		MM.getModules().enumerate(function(module) {
 			module.show(1000);
 		});
-	})
+	});
 
 	scope.registerCommand('dublinbus_start', function() {
 		scope.sendNotification("DUBLINBUS_START");
-	})
+	});
 
 	scope.registerCommand('dublinbus_stop', function() {
 		scope.sendNotification("DUBLINBUS_STOP");
-	})
+	});
 }


### PR DESCRIPTION
Following an issue on the MagicMirror itself (see issue michmich/MagicMirror#388) regarding translations, it appears that your use of `Translator.translations[this.name]...` wasn't consistent with the way MagicMirror handles langauges and fallbacks.

This PR shouldn't change any functionality, but uses the `Translator.translate` function to ensure that the code searches both the given translation and the fallbackTranslation to retrieve the necessary details.

Apologies for the fussy semicolon/formatting changes - force of habit :(
