### PR TITLE
Fixed annyang.js path to include default "dist"-directory

### DIFF
--- a/MMM-Voice-Control.js
+++ b/MMM-Voice-Control.js
@@ -10,7 +10,7 @@ Module.register("MMM-Voice-Control", {
 	},
 
 	getScripts: function() {
-		return [this.file('node_modules/annyang/annyang.js'), 'annyang-service.js', 'moment.js', 'commands.js'];
+		return [this.file('node_modules/annyang/dist/annyang.js'), 'annyang-service.js', 'moment.js', 'commands.js'];
 	},
 
 	// Define required scripts.


### PR DESCRIPTION
The default directory structure of annyang keeps the annyang.js in the dist subdirectory. Adjusted loader path accordingly.